### PR TITLE
Switch episode recording to compressed images

### DIFF
--- a/episode_recorder/config/default_config.yaml
+++ b/episode_recorder/config/default_config.yaml
@@ -3,8 +3,8 @@ episode_recorder:
     # Topics to record — add your sensor and action topics here.
     # The recorder uses GenericSubscription, so any message type works.
     topics:
-      - /follower/image_raw
-      - /static_camera/image_raw
+      - /follower/image_raw/compressed
+      - /static_camera/image_raw/compressed
       - /follower/joint_states
       - /follower/forward_controller/commands
 
@@ -25,3 +25,14 @@ episode_recorder:
     # Experiment name — used as subdirectory under root_dir and stored
     # in rosbag2 metadata.yaml custom_data. Empty = no subdirectory.
     experiment_name: "pick_and_place"
+
+    # Optional MCAP preset profile.
+    # Examples: "zstd_fast", "zstd_small"
+    # Leave empty to use backend defaults.
+    # storage_preset_profile: "zstd_fast"
+    
+    # Optional path to an MCAP storage config YAML file.
+    # Use this for advanced writer settings such as compression type,
+    # compression level, chunk size, and indexing options.
+    # Leave empty to disable custom storage config.
+    # storage_config_uri: ""

--- a/episode_recorder/include/episode_recorder/episode_recorder.hpp
+++ b/episode_recorder/include/episode_recorder/episode_recorder.hpp
@@ -46,6 +46,8 @@ private:
   double max_episode_duration_{0.0};
   std::string experiment_name_;
   std::string task_;
+  std::string storage_preset_profile_;
+  std::string storage_config_uri_;
 
   // Effective output path: root_dir_ / experiment_name_ (if set)
   std::filesystem::path output_dir_;

--- a/episode_recorder/src/episode_recorder.cpp
+++ b/episode_recorder/src/episode_recorder.cpp
@@ -29,6 +29,8 @@ EpisodeRecorder::EpisodeRecorder(const rclcpp::NodeOptions &options)
   this->declare_parameter<std::string>("experiment_name", "");
   this->declare_parameter<std::string>("task", "");
   this->declare_parameter<double>("start_gate_max_age_s", 0.5);
+  this->declare_parameter<std::string>("storage_preset_profile", "");
+  this->declare_parameter<std::string>("storage_config_uri", "");
 
   RCLCPP_INFO(get_logger(), "EpisodeRecorder node create (unconfigured)");
 }
@@ -49,6 +51,16 @@ EpisodeRecorder::on_configure(const rclcpp_lifecycle::State & /*state*/) {
   experiment_name_ = this->get_parameter("experiment_name").as_string();
   task_ = this->get_parameter("task").as_string();
   start_gate_max_age_s_ = this->get_parameter("start_gate_max_age_s").as_double();
+  storage_preset_profile_ = this->get_parameter("storage_preset_profile").as_string();
+  storage_config_uri_ = this->get_parameter("storage_config_uri").as_string();
+
+  if (!storage_preset_profile_.empty() && !storage_config_uri_.empty()) {
+    RCLCPP_WARN(
+      get_logger(),
+      "Both storage_preset_profile and storage_config_uri are set. "
+      "Prefer setting only one."
+    );
+  }
 
   if (task_.empty()) {
     RCLCPP_ERROR(get_logger(), "Parameter 'task' is empty. Provide via launch: task:=<name>");
@@ -321,6 +333,9 @@ bool EpisodeRecorder::start_episode() {
   storage_options.uri = episode_dir.string();
   storage_options.storage_id = storage_id_;
   storage_options.max_cache_size = 100u * 1024u * 1024u; // 100 MB write cache
+
+  storage_options.storage_preset_profile = storage_preset_profile_;
+  storage_options.storage_config_uri = storage_config_uri_;
 
   task_ = this->get_parameter("task").as_string();
   if (task_.empty()) {

--- a/rosbag_to_lerobot/config/so101.yaml
+++ b/rosbag_to_lerobot/config/so101.yaml
@@ -2,7 +2,7 @@ robot_type: "so101"
 fps: 30
 
 # We emit one dataset frame per message on this topic
-reference_topic: "/follower/image_raw"
+reference_topic: "/follower/image_raw/compressed"
 
 # Writtent to every frame
 task: "Pick and Place"
@@ -20,15 +20,15 @@ joint_names: &j
 features:
   # --- Reference wrist camera ---
   - key: "observation.images.wrist"
-    topic: "/follower/image_raw"
-    msg_type: "sensor_msgs/msg/Image"
+    topic: "/follower/image_raw/compressed"
+    msg_type: "sensor_msgs/msg/CompressedImage"
     stamp_src: "bag"
     shape: [480, 640, 3]
 
   # --- Static camera ---
   - key: "observation.images.top"
-    topic: "/static_camera/image_raw"
-    msg_type: "sensor_msgs/msg/Image"
+    topic: "/static_camera/image_raw/compressed"
+    msg_type: "sensor_msgs/msg/CompressedImage"
     stamp_src: "bag"
     shape: [480, 640, 3]
 

--- a/rosbag_to_lerobot/config/so101_50hz.yaml
+++ b/rosbag_to_lerobot/config/so101_50hz.yaml
@@ -20,15 +20,15 @@ joint_names: &j
 features:
   # --- Reference wrist camera ---
   - key: "observation.images.wrist"
-    topic: "/follower/image_raw"
-    msg_type: "sensor_msgs/msg/Image"
+    topic: "/follower/image_raw/compressed"
+    msg_type: "sensor_msgs/msg/CompressedImage"
     stamp_src: "bag"
     shape: [480, 640, 3]
 
   # --- Static camera ---
   - key: "observation.images.top"
-    topic: "/static_camera/image_raw"
-    msg_type: "sensor_msgs/msg/Image"
+    topic: "/static_camera/image_raw/compressed"
+    msg_type: "sensor_msgs/msg/CompressedImage"
     stamp_src: "bag"
     shape: [480, 640, 3]
 

--- a/so101_bringup/config/recording/episode_recorder_so101.yaml
+++ b/so101_bringup/config/recording/episode_recorder_so101.yaml
@@ -5,7 +5,7 @@
     storage_id: mcap
     max_episode_duration: 0.0
     topics:
-      - /follower/image_raw
-      - /static_camera/image_raw
+      - /follower/image_raw/compressed
+      - /static_camera/image_raw/compressed
       - /follower/joint_states
       - /follower/forward_controller/commands


### PR DESCRIPTION
## Switch episode recording to compressed images

* Record `/compressed` image topics instead of `/image_raw` to reduce bag sizes ~10-20x
* Update `rosbag_to_lerobot `configs to use `sensor_msgs/msg/CompressedImage` 
* Add `storage_preset_profile` and `storage_config_uri` params for future MCAP compression tuning
